### PR TITLE
Make fully transparent icons work as intended. Opacity = 0 should not make icon opaque.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "geostyler-sld-parser",
+  "name": "@geosolutions/geostyler-sld-parser",
   "version": "2.0.1",
   "description": "GeoStyler Style Parser implementation for SLD",
   "main": "build/dist/SldStyleParser.js",
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/terrestris/geostyler-sld-parser.git"
+    "url": "git+https://github.com/geosolutions-it/geostyler-sld-parser.git"
   },
   "keywords": [
     "geostyler",
@@ -40,7 +40,7 @@
     "test": "jest",
     "test:watch": "jest --watchAll",
     "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.json",
-    "release": "np --no-yarn && git push https://github.com/terrestris/geostyler-sld-parser.git master --tags"
+    "release": "np --no-yarn && git push https://github.com/geosolutions-it/geostyler-sld-parser.git master --tags"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1821,7 +1821,7 @@ export class SldStyleParser implements StyleParser {
       }
     }
 
-    if (iconSymbolizer.opacity) {
+    if (typeof iconSymbolizer.opacity !== 'undefined') {
       graphic[0].Opacity = iconSymbolizer.opacity;
     }
     if (iconSymbolizer.size) {

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -31,11 +31,14 @@ import {
   OptionsV2
 } from 'xml2js';
 
-const _isString = require('lodash/isString');
-const _isNumber = require('lodash/isNumber');
-const _get = require('lodash/get');
-const _set = require('lodash/set');
-const _isEmpty = require('lodash/isEmpty');
+import {
+  isString as _isString,
+  isNumber as _isNumber,
+  get as _get,
+  set as _set,
+  isEmpty as _isEmpty
+
+} from 'lodash';
 
 export type ConstructorParams = {
   forceCasting?: boolean,
@@ -476,7 +479,7 @@ export class SldStyleParser implements StyleParser {
     const opacity = _get(sldSymbolizer, 'Graphic[0].Opacity[0]');
     const size = _get(sldSymbolizer, 'Graphic[0].Size[0]');
     const rotate = _get(sldSymbolizer, 'Graphic[0].Rotation[0]');
-    if (opacity) {
+    if (typeof opacity !== 'undefined') {
       iconSymbolizer.opacity = opacity;
     }
     if (size) {


### PR DESCRIPTION
Original condition lead to the case when 0 opacity will be ignored and icon become opaque. This shouldn't be the case and defined value should be used as is.